### PR TITLE
Provide travis and tox testruns for all supported python versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyc
 *.pyo
 *.swp
+.cache/
 .coverage*
 .installed.cfg
 .mr.developer.cfg
@@ -15,6 +16,7 @@ docs/doctrees
 docs/html
 docs/latex
 docs/make.bat
+eggs/
 htmlcov/
 include/
 lib/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .coverage*
 .installed.cfg
 .mr.developer.cfg
+.tox
 bin/
 dev/*
 develop-eggs

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
     - 3.5
 install:
     - pip install -U -r requirements.txt
-    - buildout
+    - bin/buildout -vvv
 script:
     - test-grok
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
     - 2.7
     - 3.5
 install:
-    - pip install -r requirements.txt
+    - pip install -U -r requirements.txt
     - buildout
 script:
     - test-grok

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: python
 python:
     - 2.7
+    - 3.4
     - 3.5
+    - 3.6
+    - pypy
+    - pypy3
 install:
     - pip install -U -r requirements.txt
-    - buildout -vvv
+    - buildout -v
 script:
     - bin/test-grok
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ python:
     - 2.7
     - 3.5
 install:
-    - python bootstrap.py
-    - bin/buildout
+    - pip install -r requirements.txt
+    - buildout
 script:
-    - bin/test-grok
+    - test-grok
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
     - 3.5
 install:
     - pip install -U -r requirements.txt
-    - bin/buildout -vvv
+    - buildout -vvv
 script:
-    - test-grok
+    - bin/test-grok
 notifications:
     email: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 # ztk-versions.cfg
 setuptools==38.2.4
 zc.buildout==2.10.0
+six==1.11.0

--- a/tox.ini
+++ b/tox.ini
@@ -20,4 +20,3 @@ commands =
    {envbindir}/buildout bin-directory={envbindir}
    {envbindir}/test-grok
    /bin/rm -f {toxinidir}/.zope.teststats
-   

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+envlist =
+    py27,
+    py34,
+    py35,
+    py36,
+    pypy,
+    pypy3
+
+
+[testenv]
+deps = -rrequirements.txt
+# z3c.recipe.compattest is not tox-enabled, remove ~/.zope.teststats to avoid
+# ValueError: unsupported pickle protocol
+whitelist-externals = /bin/rm
+setenv =
+   HOME={toxinidir}
+commands =
+   /bin/rm -f {toxinidir}/.zope.teststats
+   {envbindir}/buildout bin-directory={envbindir}
+   {envbindir}/test-grok
+   /bin/rm -f {toxinidir}/.zope.teststats
+   


### PR DESCRIPTION
This will take a loooong time on the first tox run, because it needs to fill the full local eggs cache for each separate python version (shared eggs directory, but per-python-version eggs). Once the eggs are there, a full tox run is acceptable.