### PR TITLE
Drop ``z3c.checkversions`` from GROK toolkit.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,9 +1,7 @@
 [buildout]
 extends =
    grok.cfg
-
 parts =
-  checkversions
   test
 
 extensions = mr.developer
@@ -13,10 +11,6 @@ auto-checkout =
 
 [sources]
 # Add sources here where you need to override the branch
-
-[checkversions]
-recipe = zc.recipe.egg
-eggs = z3c.checkversions [buildout]
 
 [test]
 recipe = z3c.recipe.compattest

--- a/dependabot/requirements.txt
+++ b/dependabot/requirements.txt
@@ -81,7 +81,6 @@ coverage==7.13.5
 manuel==1.13.0
 collective.recipe.cmd==0.11
 mr.developer==2.0.4
-z3c.checkversions==3.0
 z3c.recipe.compattest==4.0
 zc.recipe.egg==4.0.0
 zc.recipe.testrunner==4.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,9 @@
   tests here so we no longer depend on ZTK releases to see updates of these
   versions.
 
+- Drop ``z3c.checkversions`` from GROK toolkit as it is archived because it
+  does not support native namespaces.
+
 5.4 (2025-06-10)
 ----------------
 

--- a/grok-sources.cfg
+++ b/grok-sources.cfg
@@ -69,9 +69,6 @@ zope.traversing = git ${buildout:github}/zope.traversing pushurl=${buildout:gith
 zope.untrustedpython = git ${buildout:github}/zope.untrustedpython pushurl=${buildout:github_push}/zope.untrustedpython
 zope.viewlet = git ${buildout:github}/zope.viewlet pushurl=${buildout:github_push}/zope.viewlet
 
-# Tools
-z3c.checkversions = git ${buildout:github}/z3c.checkversions pushurl=${buildout:github_push}/z3c.checkversions
-
 # GROK
 grok = git ${buildout:github}/grok pushurl=${buildout:github_push}/grok
 grokcore.annotation = git ${buildout:github}/grokcore.annotation pushurl=${buildout:github_push}/grokcore.annotation

--- a/grok-versions.cfg
+++ b/grok-versions.cfg
@@ -91,7 +91,6 @@ manuel = 1.13.0
 # ZTK buildout dependencies
 collective.recipe.cmd = 0.11
 mr.developer = 2.0.4
-z3c.checkversions = 3.0
 z3c.recipe.compattest = 4.0
 zc.recipe.egg = 4.0.0
 zc.recipe.testrunner = 4.0


### PR DESCRIPTION
It is archived because it does not support native namespaces.
